### PR TITLE
bugfix, added last detected trigger to use for binning

### DIFF
--- a/pymepix/processing/logic/packet_processor.py
+++ b/pymepix/processing/logic/packet_processor.py
@@ -304,7 +304,7 @@ class PacketProcessor(ProcessingStep):
                         self.error("Flushing triggers!!!")
                         self._triggers = self._triggers[-2:]
                         return None
-                    self._triggers = self._triggers[-2:]
+                    self._triggers = self._triggers[-1:]
 
                     tof = toa - start[event_mapping]
                     event_number = trigger_counter[event_mapping]

--- a/pymepix/processing/logic/packet_processor.py
+++ b/pymepix/processing/logic/packet_processor.py
@@ -279,8 +279,8 @@ class PacketProcessor(ProcessingStep):
 
             if self.__toa_is_not_empty():
                 # Get our start/end triggers to bin events accordingly
-                start = self._triggers[0:-1:]
-                if start.size > 0:
+                start = self._triggers
+                if start.size > 1:
                     trigger_counter = np.arange(
                         self._trigger_counter, self._trigger_counter + start.size - 1, dtype=int
                     )


### PR DESCRIPTION
For some reason the very last trigger event have not been used for binning of pixels into trigger events. There is also strange tome me array slicing have been used [0:-1:], which is equivalent to [:-1], that leads to ignore of last trigger event [-1] from further processing. Exception was thrown, when only two triggers were in array self._triggers of class PacketProcessor in function def find_events_fast(self) .